### PR TITLE
audit: add check to ensure nft and base token have contract code

### DIFF
--- a/src/Caviar.sol
+++ b/src/Caviar.sol
@@ -28,6 +28,8 @@ contract Caviar is Owned {
     function create(address nft, address baseToken, bytes32 merkleRoot) public returns (Pair pair) {
         // check that the pair doesn't already exist
         require(pairs[nft][baseToken][merkleRoot] == address(0), "Pair already exists");
+        require(nft.code.length > 0, "Invalid NFT contract");
+        require(baseToken.code.length > 0 || baseToken == address(0), "Invalid base token contract");
 
         // deploy the pair
         string memory baseTokenSymbol = baseToken == address(0) ? "ETH" : baseToken.tokenSymbol();


### PR DESCRIPTION
Fixes: https://github.com/code-423n4/2022-12-caviar-findings/issues/245

Ensures that for a new pair the nft contract and base token contract already exist.