### PR TITLE
audit: add min/max price checks when adding liquidity

### DIFF
--- a/test/Pair/integration/AddBuySellRemove.t.sol
+++ b/test/Pair/integration/AddBuySellRemove.t.sol
@@ -22,7 +22,7 @@ contract AddBuySellRemoveTest is Fixture {
         deal(address(p), address(this), addFractionalTokenAmount, true);
         uint256 lpTokenAmount = Math.sqrt(addBaseTokenAmount * addFractionalTokenAmount);
         usd.approve(address(p), type(uint256).max);
-        p.add(addBaseTokenAmount, addFractionalTokenAmount, lpTokenAmount);
+        p.add(addBaseTokenAmount, addFractionalTokenAmount, lpTokenAmount, 0, type(uint256).max);
 
         // buy some amount
         uint256 baseTokenBuyAmount = p.buyQuote(buyTokenAmount);

--- a/test/Pair/integration/BuySell.t.sol
+++ b/test/Pair/integration/BuySell.t.sol
@@ -18,10 +18,12 @@ contract BuySellTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         deal(address(ethPair), address(this), fractionalTokenAmount, true);
-        ethPair.add{value: baseTokenAmount}(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
+        ethPair.add{value: baseTokenAmount}(
+            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+        );
     }
 
     function testItBuysSellsEqualAmounts(uint256 outputAmount) public {

--- a/test/Pair/unit/Buy.t.sol
+++ b/test/Pair/unit/Buy.t.sol
@@ -23,14 +23,16 @@ contract BuyTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         maxInputAmount =
             (outputAmount * p.baseTokenReserves() * 1000) / ((p.fractionalTokenReserves() - outputAmount) * 997);
         deal(address(usd), address(this), maxInputAmount, true);
 
         deal(address(ethPair), address(this), fractionalTokenAmount, true);
-        ethPair.add{value: baseTokenAmount}(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
+        ethPair.add{value: baseTokenAmount}(
+            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+        );
     }
 
     function testItReturnsInputAmount() public {

--- a/test/Pair/unit/NftAdd.t.sol
+++ b/test/Pair/unit/NftAdd.t.sol
@@ -30,7 +30,7 @@ contract NftAddTest is Fixture {
         uint256 expectedLpTokenAmount = minLpTokenAmount;
 
         // act
-        uint256 lpTokenAmount = p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        uint256 lpTokenAmount = p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
 
         // assert
         assertEq(lpTokenAmount, expectedLpTokenAmount, "Should have returned correct lp token amount");
@@ -44,7 +44,7 @@ contract NftAddTest is Fixture {
         uint256 balanceBefore = usd.balanceOf(address(this));
 
         // act
-        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
 
         // assert
         uint256 balanceAfter = usd.balanceOf(address(this));
@@ -57,7 +57,7 @@ contract NftAddTest is Fixture {
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
 
         // act
-        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
 
         // assert
         for (uint256 i = 0; i < tokenIds.length; i++) {
@@ -71,7 +71,7 @@ contract NftAddTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: lp token amount out");
-        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
     }
 
     function testItMintsLpTokensAfterInit() public {
@@ -79,7 +79,7 @@ contract NftAddTest is Fixture {
         uint256 fractionalTokenAmount = 101 * 1e18;
         deal(address(p), address(this), fractionalTokenAmount, true);
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount); // initial add
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
         uint256 lpTokenSupplyBefore = lpToken.totalSupply();
 
         uint256 expectedLpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
@@ -98,7 +98,7 @@ contract NftAddTest is Fixture {
         }
 
         // act
-        uint256 lpTokenAmount = p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        uint256 lpTokenAmount = p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
         vm.stopPrank();
 
         // assert
@@ -112,14 +112,14 @@ contract NftAddTest is Fixture {
         uint256 fractionalTokenAmount = 101 * 1e18;
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
         deal(address(p), address(this), fractionalTokenAmount, true);
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount); // initial add
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
 
         minLpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves() + 1; // add 1 to cause a revert
         baseTokenAmount = ((p.baseTokenReserves() + 100) * tokenIds.length * 1e18) / p.fractionalTokenReserves();
 
         // act
         vm.expectRevert("Slippage: lp token amount out");
-        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
     }
 
     function testItAddsWithMerkleProof() public {
@@ -131,7 +131,7 @@ contract NftAddTest is Fixture {
         usd.approve(address(pair), type(uint256).max);
 
         // act
-        pair.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        pair.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
 
         // assert
         for (uint256 i = 0; i < tokenIds.length; i++) {

--- a/test/Pair/unit/NftBuy.t.sol
+++ b/test/Pair/unit/NftBuy.t.sol
@@ -25,7 +25,7 @@ contract NftBuyTest is Fixture {
         uint256 baseTokenAmount = 3.15e18;
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
         deal(address(usd), address(this), baseTokenAmount, true);
-        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
 
         tokenIds.pop();
         tokenIds.pop();

--- a/test/Pair/unit/NftRemove.t.sol
+++ b/test/Pair/unit/NftRemove.t.sol
@@ -24,7 +24,7 @@ contract NftRemoveTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(totalBaseTokenAmount * tokenIds.length * 1e18);
-        totalLpTokenAmount = p.nftAdd(totalBaseTokenAmount, tokenIds, minLpTokenAmount, proofs);
+        totalLpTokenAmount = p.nftAdd(totalBaseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
 
         tokenIds.pop();
         tokenIds.pop();

--- a/test/Pair/unit/NftSell.t.sol
+++ b/test/Pair/unit/NftSell.t.sol
@@ -21,7 +21,7 @@ contract NftSellTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         for (uint256 i = 0; i < 5; i++) {
             bayc.mint(address(this), i);
@@ -112,7 +112,7 @@ contract NftSellTest is Fixture {
         usd.approve(address(pair), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
-        pair.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
+        pair.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         proofs = createPairScript.generateMerkleProofs("YEET-mids.json", tokenIds);
         bayc.setApprovalForAll(address(pair), true);

--- a/test/Pair/unit/Remove.t.sol
+++ b/test/Pair/unit/Remove.t.sol
@@ -21,10 +21,13 @@ contract RemoveTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(totalBaseTokenAmount * totalFractionalTokenAmount);
-        totalLpTokenAmount = p.add(totalBaseTokenAmount, totalFractionalTokenAmount, minLpTokenAmount);
+        totalLpTokenAmount =
+            p.add(totalBaseTokenAmount, totalFractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         deal(address(ethPair), address(this), totalFractionalTokenAmount, true);
-        ethPair.add{value: totalBaseTokenAmount}(totalBaseTokenAmount, totalFractionalTokenAmount, minLpTokenAmount);
+        ethPair.add{value: totalBaseTokenAmount}(
+            totalBaseTokenAmount, totalFractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+        );
     }
 
     function testItReturnsBaseTokenAmountAndFractionalTokenAmount() public {

--- a/test/Pair/unit/Sell.t.sol
+++ b/test/Pair/unit/Sell.t.sol
@@ -23,14 +23,16 @@ contract SellTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         minOutputAmount =
             (inputAmount * 997 * p.baseTokenReserves()) / ((p.fractionalTokenReserves() * 1000 + inputAmount * 997));
         deal(address(p), address(this), inputAmount, true);
 
         deal(address(ethPair), address(this), fractionalTokenAmount, true);
-        ethPair.add{value: baseTokenAmount}(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
+        ethPair.add{value: baseTokenAmount}(
+            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+        );
         deal(address(ethPair), address(this), inputAmount, true);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/code-423n4/2022-12-caviar-findings/issues/376

Adds bounds to check for price slippage when adding liquidity ensuring that the LP is always adding at a desired ratio of reserves.