### PR TITLE
audit: send the first 1000 lp tokens to caviar owner

### DIFF
--- a/src/Pair.sol
+++ b/src/Pair.sol
@@ -7,8 +7,6 @@ import "solmate/utils/MerkleProofLib.sol";
 import "solmate/utils/SafeTransferLib.sol";
 import "openzeppelin/utils/math/Math.sol";
 
-import "forge-std/console.sol";
-
 import "./LpToken.sol";
 import "./Caviar.sol";
 

--- a/src/Pair.sol
+++ b/src/Pair.sol
@@ -7,6 +7,8 @@ import "solmate/utils/MerkleProofLib.sol";
 import "solmate/utils/SafeTransferLib.sol";
 import "openzeppelin/utils/math/Math.sol";
 
+import "forge-std/console.sol";
+
 import "./LpToken.sol";
 import "./Caviar.sol";
 
@@ -19,6 +21,7 @@ contract Pair is ERC20, ERC721TokenReceiver {
 
     uint256 public constant ONE = 1e18;
     uint256 public constant CLOSE_GRACE_PERIOD = 7 days;
+    uint256 private constant MINIMUM_LIQUIDITY = 1000;
 
     address public immutable nft;
     address public immutable baseToken; // address(0) for ETH
@@ -77,14 +80,16 @@ contract Pair is ERC20, ERC721TokenReceiver {
         // check that correct eth input was sent - if the baseToken equals address(0) then native ETH is used
         require(baseToken == address(0) ? msg.value == baseTokenAmount : msg.value == 0, "Invalid ether input");
 
+        uint256 lpTokenSupply = lpToken.totalSupply();
+
         // check that the price is within the bounds if there is liquidity in the pool
-        if (lpToken.totalSupply() != 0) {
+        if (lpTokenSupply != 0) {
             uint256 _price = price();
             require(_price >= minPrice && _price <= maxPrice, "Slippage: price out of bounds");
         }
 
         // calculate the lp token shares to mint
-        lpTokenAmount = addQuote(baseTokenAmount, fractionalTokenAmount);
+        lpTokenAmount = addQuote(baseTokenAmount, fractionalTokenAmount, lpTokenSupply);
 
         // check that the amount of lp tokens outputted is greater than the min amount
         require(lpTokenAmount >= minLpTokenAmount, "Slippage: lp token amount out");
@@ -98,6 +103,11 @@ contract Pair is ERC20, ERC721TokenReceiver {
 
         // mint lp tokens to sender
         lpToken.mint(msg.sender, lpTokenAmount);
+
+        // transfer first MINIMUM_LIQUIDITY lp tokens to the owner
+        if (lpTokenSupply == 0) {
+            lpToken.mint(caviar.owner(), MINIMUM_LIQUIDITY);
+        }
 
         // transfer base tokens in if the base token is not ETH
         if (baseToken != address(0)) {
@@ -440,16 +450,19 @@ contract Pair is ERC20, ERC721TokenReceiver {
     /// @param baseTokenAmount The amount of base tokens to add.
     /// @param fractionalTokenAmount The amount of fractional tokens to add.
     /// @return lpTokenAmount The amount of lp tokens received.
-    function addQuote(uint256 baseTokenAmount, uint256 fractionalTokenAmount) public view returns (uint256) {
-        uint256 lpTokenSupply = lpToken.totalSupply();
-        if (lpTokenSupply > 0) {
+    function addQuote(uint256 baseTokenAmount, uint256 fractionalTokenAmount, uint256 lpTokenSupply)
+        public
+        view
+        returns (uint256)
+    {
+        if (lpTokenSupply != 0) {
             // calculate amount of lp tokens as a fraction of existing reserves
             uint256 baseTokenShare = (baseTokenAmount * lpTokenSupply) / baseTokenReserves();
             uint256 fractionalTokenShare = (fractionalTokenAmount * lpTokenSupply) / fractionalTokenReserves();
             return Math.min(baseTokenShare, fractionalTokenShare);
         } else {
             // if there is no liquidity then init
-            return Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+            return Math.sqrt(baseTokenAmount * fractionalTokenAmount) - MINIMUM_LIQUIDITY;
         }
     }
 

--- a/test/Pair/integration/AddBuySellRemove.t.sol
+++ b/test/Pair/integration/AddBuySellRemove.t.sol
@@ -13,14 +13,14 @@ contract AddBuySellRemoveTest is Fixture {
         uint256 addFractionalTokenAmount,
         uint256 buyTokenAmount
     ) public {
-        addBaseTokenAmount = bound(addBaseTokenAmount, 100, type(uint96).max);
-        addFractionalTokenAmount = bound(addFractionalTokenAmount, 2, 10_000_000 * 1e18);
+        addBaseTokenAmount = bound(addBaseTokenAmount, 10000, type(uint96).max);
+        addFractionalTokenAmount = bound(addFractionalTokenAmount, 10000, 10_000_000 * 1e18);
         buyTokenAmount = bound(buyTokenAmount, 1, addFractionalTokenAmount - 1);
 
         // add liquidity
         deal(address(usd), address(this), addBaseTokenAmount, true);
         deal(address(p), address(this), addFractionalTokenAmount, true);
-        uint256 lpTokenAmount = Math.sqrt(addBaseTokenAmount * addFractionalTokenAmount);
+        uint256 lpTokenAmount = Math.sqrt(addBaseTokenAmount * addFractionalTokenAmount) - 1000;
         usd.approve(address(p), type(uint256).max);
         p.add(addBaseTokenAmount, addFractionalTokenAmount, lpTokenAmount, 0, type(uint256).max);
 

--- a/test/Pair/integration/BuySell.t.sol
+++ b/test/Pair/integration/BuySell.t.sol
@@ -17,7 +17,7 @@ contract BuySellTest is Fixture {
 
         usd.approve(address(p), type(uint256).max);
 
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         deal(address(ethPair), address(this), fractionalTokenAmount, true);

--- a/test/Pair/unit/Add.t.sol
+++ b/test/Pair/unit/Add.t.sol
@@ -11,8 +11,8 @@ import "../../../script/CreatePair.s.sol";
 contract AddTest is Fixture {
     event Add(uint256 baseTokenAmount, uint256 fractionalTokenAmount, uint256 lpTokenAmount);
 
-    uint256 public baseTokenAmount = 100;
-    uint256 public fractionalTokenAmount = 30;
+    uint256 public baseTokenAmount = 10000;
+    uint256 public fractionalTokenAmount = 300;
 
     function setUp() public {
         deal(address(usd), address(this), baseTokenAmount, true);
@@ -23,22 +23,13 @@ contract AddTest is Fixture {
     }
 
     function testItInitMintsLpTokensToSender() public {
-        // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
-        uint256 expectedLpTokenAmount = minLpTokenAmount;
-
         // act
-        uint256 lpTokenAmount = p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
-
-        // assert
-        assertEq(lpTokenAmount, expectedLpTokenAmount, "Should have returned correct lp token amount");
-        assertEq(lpToken.balanceOf(address(this)), expectedLpTokenAmount, "Should have minted lp tokens");
-        assertEq(lpToken.totalSupply(), expectedLpTokenAmount, "Should have increased lp supply");
+        testItInitMintsLpTokensToSender(baseTokenAmount, fractionalTokenAmount);
     }
 
     function testItTransfersBaseTokens() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         uint256 balanceBefore = usd.balanceOf(address(this));
 
         // act
@@ -52,7 +43,7 @@ contract AddTest is Fixture {
 
     function testItTransfersFractionalTokens() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         uint256 balanceBefore = p.balanceOf(address(this));
 
         // act
@@ -69,7 +60,7 @@ contract AddTest is Fixture {
 
     function testItRevertsSlippageOnInitMint() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) + 1; // increase 1 to cause revert
+        uint256 minLpTokenAmount = (Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000) + 1; // increase 1 to cause revert
 
         // act
         vm.expectRevert("Slippage: lp token amount out");
@@ -78,7 +69,7 @@ contract AddTest is Fixture {
 
     function testItMintsLpTokensAfterInit() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
         uint256 lpTokenSupplyBefore = lpToken.totalSupply();
 
@@ -103,7 +94,7 @@ contract AddTest is Fixture {
 
     function testItRevertsIfPriceIsGreaterThanMax() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
 
         uint256 expectedLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) * 17;
@@ -120,7 +111,7 @@ contract AddTest is Fixture {
 
     function testItRevertsIfPriceIsLessThanMin() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
 
         uint256 expectedLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) * 17;
@@ -137,7 +128,7 @@ contract AddTest is Fixture {
 
     function testItRevertsSlippageAfterInitMint() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
 
         minLpTokenAmount = (baseTokenAmount * fractionalTokenAmount * 17) + 1; // add 1 to cause a revert
@@ -175,7 +166,7 @@ contract AddTest is Fixture {
 
     function testItTransfersEther() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         uint256 balanceBefore = address(this).balance;
 
         // act
@@ -191,7 +182,7 @@ contract AddTest is Fixture {
 
     function testItMintsLpTokensAfterInitWithEther() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         ethPair.add{value: baseTokenAmount}(
             baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
         ); // initial add
@@ -221,7 +212,7 @@ contract AddTest is Fixture {
 
     function testItEmitsAddEvent() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
 
         // act
         vm.expectEmit(true, true, true, true);
@@ -240,12 +231,14 @@ contract AddTest is Fixture {
 
     function testItInitMintsLpTokensToSender(uint256 _baseTokenAmount, uint256 _fractionalTokenAmount) public {
         // arrange
-        _baseTokenAmount = bound(_baseTokenAmount, 1, type(uint128).max);
-        _fractionalTokenAmount = bound(_fractionalTokenAmount, 1, 100_000_000 * 1e18);
+        _baseTokenAmount = bound(_baseTokenAmount, 2000, type(uint128).max);
+        _fractionalTokenAmount = bound(_fractionalTokenAmount, 2000, 100_000_000 * 1e18);
         deal(address(usd), address(this), _baseTokenAmount, true);
         deal(address(p), address(this), _fractionalTokenAmount, true);
-        uint256 minLpTokenAmount = Math.sqrt(_baseTokenAmount * _fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(_baseTokenAmount * _fractionalTokenAmount) - 1000;
         uint256 expectedLpTokenAmount = minLpTokenAmount;
+        address owner = address(0xbeef);
+        c.transferOwnership(owner);
 
         // act
         uint256 lpTokenAmount = p.add(_baseTokenAmount, _fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
@@ -253,16 +246,17 @@ contract AddTest is Fixture {
         // assert
         assertEq(lpTokenAmount, expectedLpTokenAmount, "Should have returned correct lp token amount");
         assertEq(lpToken.balanceOf(address(this)), expectedLpTokenAmount, "Should have minted lp tokens");
-        assertEq(lpToken.totalSupply(), expectedLpTokenAmount, "Should have increased lp supply");
+        assertEq(lpToken.totalSupply(), expectedLpTokenAmount + 1000, "Should have increased lp supply");
+        assertEq(lpToken.balanceOf(address(owner)), 1000, "Should have minted first 1000 lp tokens for owner");
     }
 
     function testItMintsLpTokensAfterInit(uint256 _initBaseTokenAmount, uint256 _initFractionalTokenAmount) public {
         // arrange
-        _initBaseTokenAmount = bound(_initBaseTokenAmount, 1, type(uint128).max);
-        _initFractionalTokenAmount = bound(_initFractionalTokenAmount, 1, 100_000_000 * 1e18);
+        _initBaseTokenAmount = bound(_initBaseTokenAmount, 2000, type(uint128).max);
+        _initFractionalTokenAmount = bound(_initFractionalTokenAmount, 2000, 100_000_000 * 1e18);
         deal(address(usd), address(this), _initBaseTokenAmount, true);
         deal(address(p), address(this), _initFractionalTokenAmount, true);
-        uint256 initMinLpTokenAmount = Math.sqrt(_initBaseTokenAmount * _initFractionalTokenAmount);
+        uint256 initMinLpTokenAmount = Math.sqrt(_initBaseTokenAmount * _initFractionalTokenAmount) - 1000;
         p.add(_initBaseTokenAmount, _initFractionalTokenAmount, initMinLpTokenAmount, 0, type(uint256).max); // initial add
         uint256 lpTokenSupplyBefore = lpToken.totalSupply();
 

--- a/test/Pair/unit/Buy.t.sol
+++ b/test/Pair/unit/Buy.t.sol
@@ -22,7 +22,7 @@ contract BuyTest is Fixture {
 
         usd.approve(address(p), type(uint256).max);
 
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         maxInputAmount =

--- a/test/Pair/unit/NftAdd.t.sol
+++ b/test/Pair/unit/NftAdd.t.sol
@@ -26,8 +26,10 @@ contract NftAddTest is Fixture {
 
     function testItInitMintsLpTokensToSender() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) - 1000;
         uint256 expectedLpTokenAmount = minLpTokenAmount;
+        address owner = address(0xdead);
+        c.transferOwnership(owner);
 
         // act
         uint256 lpTokenAmount = p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
@@ -35,12 +37,13 @@ contract NftAddTest is Fixture {
         // assert
         assertEq(lpTokenAmount, expectedLpTokenAmount, "Should have returned correct lp token amount");
         assertEq(lpToken.balanceOf(address(this)), expectedLpTokenAmount, "Should have minted lp tokens");
-        assertEq(lpToken.totalSupply(), expectedLpTokenAmount, "Should have increased lp supply");
+        assertEq(lpToken.totalSupply(), expectedLpTokenAmount + 1000, "Should have increased lp supply");
+        assertEq(lpToken.balanceOf(owner), 1000, "Should have minted 1000 lp tokens to owner");
     }
 
     function testItTransfersBaseTokens() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) - 1000;
         uint256 balanceBefore = usd.balanceOf(address(this));
 
         // act
@@ -54,7 +57,7 @@ contract NftAddTest is Fixture {
 
     function testItTransfersNfts() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) - 1000;
 
         // act
         p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
@@ -67,7 +70,7 @@ contract NftAddTest is Fixture {
 
     function testItRevertsSlippageOnInitMint() public {
         // arrange
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) + 1; // increase 1 to cause revert
+        uint256 minLpTokenAmount = (Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) - 1000) + 1; // increase 1 to cause revert
 
         // act
         vm.expectRevert("Slippage: lp token amount out");
@@ -78,7 +81,7 @@ contract NftAddTest is Fixture {
         // arrange
         uint256 fractionalTokenAmount = 101 * 1e18;
         deal(address(p), address(this), fractionalTokenAmount, true);
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
         uint256 lpTokenSupplyBefore = lpToken.totalSupply();
 
@@ -110,7 +113,7 @@ contract NftAddTest is Fixture {
     function testItRevertsSlippageAfterInitMint() public {
         // arrange
         uint256 fractionalTokenAmount = 101 * 1e18;
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) - 1000;
         deal(address(p), address(this), fractionalTokenAmount, true);
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
 
@@ -126,7 +129,7 @@ contract NftAddTest is Fixture {
         // arrange
         Pair pair = createPairScript.create(address(bayc), address(usd), "YEET-mids.json", address(c));
         proofs = createPairScript.generateMerkleProofs("YEET-mids.json", tokenIds);
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) - 1000;
         bayc.setApprovalForAll(address(pair), true);
         usd.approve(address(pair), type(uint256).max);
 

--- a/test/Pair/unit/NftBuy.t.sol
+++ b/test/Pair/unit/NftBuy.t.sol
@@ -23,7 +23,7 @@ contract NftBuyTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 baseTokenAmount = 3.15e18;
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * tokenIds.length * 1e18) - 1000;
         deal(address(usd), address(this), baseTokenAmount, true);
         p.nftAdd(baseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
 

--- a/test/Pair/unit/NftRemove.t.sol
+++ b/test/Pair/unit/NftRemove.t.sol
@@ -23,7 +23,7 @@ contract NftRemoveTest is Fixture {
         bayc.setApprovalForAll(address(p), true);
         usd.approve(address(p), type(uint256).max);
 
-        uint256 minLpTokenAmount = Math.sqrt(totalBaseTokenAmount * tokenIds.length * 1e18);
+        uint256 minLpTokenAmount = Math.sqrt(totalBaseTokenAmount * tokenIds.length * 1e18) - 1000;
         totalLpTokenAmount = p.nftAdd(totalBaseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
 
         tokenIds.pop();
@@ -33,8 +33,8 @@ contract NftRemoveTest is Fixture {
 
     function testItReturnsBaseTokenAmountAndFractionalTokenAmount() public {
         // arrange
-        uint256 lpTokenAmount = (totalLpTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
-        uint256 expectedBaseTokenAmount = (totalBaseTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 lpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 expectedBaseTokenAmount = (p.baseTokenReserves() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
         uint256 expectedFractionalTokenAmount = tokenIds.length * 1e18;
 
         // act
@@ -50,8 +50,9 @@ contract NftRemoveTest is Fixture {
 
     function testItBurnsLpTokens() public {
         // arrange
-        uint256 lpTokenAmount = (totalLpTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
-        uint256 minBaseTokenOutputAmount = (totalBaseTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 lpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 minBaseTokenOutputAmount =
+            (p.baseTokenReserves() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
         uint256 balanceBefore = lpToken.balanceOf(address(this));
         uint256 totalSupplyBefore = lpToken.totalSupply();
 
@@ -67,8 +68,9 @@ contract NftRemoveTest is Fixture {
 
     function testItTransfersBaseTokens() public {
         // arrange
-        uint256 lpTokenAmount = (totalLpTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
-        uint256 minBaseTokenOutputAmount = (totalBaseTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 lpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 minBaseTokenOutputAmount =
+            (p.baseTokenReserves() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
         uint256 thisBalanceBefore = usd.balanceOf(address(this));
         uint256 balanceBefore = usd.balanceOf(address(p));
 
@@ -91,8 +93,9 @@ contract NftRemoveTest is Fixture {
 
     function testItTransfersNfts() public {
         // arrange
-        uint256 lpTokenAmount = (totalLpTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
-        uint256 minBaseTokenOutputAmount = (totalBaseTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 lpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 minBaseTokenOutputAmount =
+            (p.baseTokenReserves() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
 
         // act
         p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, tokenIds, false);
@@ -105,8 +108,9 @@ contract NftRemoveTest is Fixture {
 
     function testItRevertsNftSlippage() public {
         // arrange
-        uint256 lpTokenAmount = (totalLpTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
-        uint256 minBaseTokenOutputAmount = (totalBaseTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 lpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 minBaseTokenOutputAmount =
+            (p.baseTokenReserves() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
         tokenIds.push(100); // add a token to cause revert
 
         // act
@@ -116,9 +120,9 @@ contract NftRemoveTest is Fixture {
 
     function testItRevertsBaseTokenSlippage() public {
         // arrange
-        uint256 lpTokenAmount = (totalLpTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves();
+        uint256 lpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
         uint256 minBaseTokenOutputAmount =
-            (totalBaseTokenAmount * tokenIds.length * 1e18) / p.fractionalTokenReserves() + 1; // add 1 to cause revert
+            (p.baseTokenReserves() * tokenIds.length * 1e18) / p.fractionalTokenReserves() + 1; // add 1 to cause revert
 
         // act
         vm.expectRevert("Slippage: base token amount out");

--- a/test/Pair/unit/NftSell.t.sol
+++ b/test/Pair/unit/NftSell.t.sol
@@ -20,7 +20,7 @@ contract NftSellTest is Fixture {
         deal(address(p), address(this), fractionalTokenAmount, true);
         usd.approve(address(p), type(uint256).max);
 
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         for (uint256 i = 0; i < 5; i++) {
@@ -111,7 +111,7 @@ contract NftSellTest is Fixture {
         deal(address(pair), address(this), fractionalTokenAmount, true);
         usd.approve(address(pair), type(uint256).max);
 
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         pair.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         proofs = createPairScript.generateMerkleProofs("YEET-mids.json", tokenIds);

--- a/test/Pair/unit/Sell.t.sol
+++ b/test/Pair/unit/Sell.t.sol
@@ -22,7 +22,7 @@ contract SellTest is Fixture {
 
         usd.approve(address(p), type(uint256).max);
 
-        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount);
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
 
         minOutputAmount =


### PR DESCRIPTION
Fixes: https://github.com/code-423n4/2022-12-caviar-findings/issues/442

Ensures that the first 1000 LP tokens are sent to the caviar owner to avoid rounding manipulations in the LP token to reserves ratio.