### PR TITLE
audit: round up buy quote

### DIFF
--- a/src/Pair.sol
+++ b/src/Pair.sol
@@ -5,6 +5,7 @@ import "solmate/tokens/ERC20.sol";
 import "solmate/tokens/ERC721.sol";
 import "solmate/utils/MerkleProofLib.sol";
 import "solmate/utils/SafeTransferLib.sol";
+import "solmate/utils/FixedPointMathLib.sol";
 import "openzeppelin/utils/math/Math.sol";
 
 import "./LpToken.sol";
@@ -430,7 +431,9 @@ contract Pair is ERC20, ERC721TokenReceiver {
     /// @param outputAmount The amount of fractional tokens to buy.
     /// @return inputAmount The amount of base tokens required.
     function buyQuote(uint256 outputAmount) public view returns (uint256) {
-        return (outputAmount * 1000 * baseTokenReserves()) / ((fractionalTokenReserves() - outputAmount) * 997);
+        return FixedPointMathLib.mulDivUp(
+            outputAmount * 1000, baseTokenReserves(), (fractionalTokenReserves() - outputAmount) * 997
+        );
     }
 
     /// @notice The amount of base tokens received for selling a given amount of fractional tokens.

--- a/test/Pair/integration/BuySell.t.sol
+++ b/test/Pair/integration/BuySell.t.sol
@@ -29,7 +29,7 @@ contract BuySellTest is Fixture {
     function testItBuysSellsEqualAmounts(uint256 outputAmount) public {
         outputAmount = bound(outputAmount, 1e2, p.fractionalTokenReserves() - 1e18);
         uint256 maxInputAmount =
-            (outputAmount * p.baseTokenReserves() * 1000) / ((p.fractionalTokenReserves() - outputAmount) * 997);
+            (outputAmount * p.baseTokenReserves() * 1000) / ((p.fractionalTokenReserves() - outputAmount) * 997) + 1;
         deal(address(usd), address(this), maxInputAmount, true);
 
         // act
@@ -40,7 +40,7 @@ contract BuySellTest is Fixture {
         assertApproxEqAbs(
             usd.balanceOf(address(this)),
             maxInputAmount,
-            maxInputAmount - (((maxInputAmount * 997) / 1000) * 997) / 1000, // allow margin of error for approx. fee amount
+            maxInputAmount - (((maxInputAmount * 997) / 1000) * 997) / 1000 + 1, // allow margin of error for approx. fee amount
             "Should have bought and sold equal amounts of assets"
         );
 

--- a/test/Pair/unit/NftBuy.t.sol
+++ b/test/Pair/unit/NftBuy.t.sol
@@ -31,7 +31,7 @@ contract NftBuyTest is Fixture {
         tokenIds.pop();
         outputAmount = tokenIds.length * 1e18;
         maxInputAmount =
-            (outputAmount * p.baseTokenReserves() * 1000) / ((p.fractionalTokenReserves() - outputAmount) * 997);
+            (outputAmount * p.baseTokenReserves() * 1000) / ((p.fractionalTokenReserves() - outputAmount) * 997) + 1;
         deal(address(usd), address(this), maxInputAmount, true);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/code-423n4/2022-12-caviar-findings/issues/243

Rounds up the buy quote instead of rounding down.