### PR TITLE
audit: ensure 18 decimals of precision in price()

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ libs = ["lib"]
 solc = "0.8.17"
 optimizer_runs = 3_000
 gas_reports = ["Pair", "Caviar", "LpToken"]
-fs_permissions = [{ access = "read", path = "./script/rankings/"}]
+fs_permissions = [{ access = "read", path = "./script/rankings/" }]
 ffi = true
 
 [fmt]

--- a/src/Pair.sol
+++ b/src/Pair.sol
@@ -423,7 +423,8 @@ contract Pair is ERC20, ERC721TokenReceiver {
     /// @dev Calculated by dividing the base token reserves by the fractional token reserves.
     /// @return price The price of one fractional token in base tokens * 1e18.
     function price() public view returns (uint256) {
-        return (_baseTokenReserves() * ONE) / fractionalTokenReserves();
+        uint256 exponent = baseToken == address(0) ? 18 : (36 - ERC20(baseToken).decimals());
+        return (_baseTokenReserves() * 10 ** exponent) / fractionalTokenReserves();
     }
 
     /// @notice The amount of base tokens required to buy a given amount of fractional tokens.

--- a/test/Pair/unit/Price.t.sol
+++ b/test/Pair/unit/Price.t.sol
@@ -13,7 +13,34 @@ contract PriceTest is Fixture {
         // arrange
         uint256 baseTokenReserves = 500;
         uint256 fractionalTokenReserves = 1000;
-        uint256 expectedPrice = baseTokenReserves * 1e18 / fractionalTokenReserves;
+        uint256 expectedPrice = (baseTokenReserves * 10 ** (36 - 6)) / fractionalTokenReserves;
+
+        // forgefmt: disable-next-item
+        stdstore
+            .target(address(usd))
+            .sig("balanceOf(address)")
+            .with_key(address(p))
+            .checked_write(baseTokenReserves);
+
+        // forgefmt: disable-next-item
+        stdstore
+            .target(address(p))
+            .sig("balanceOf(address)")
+            .with_key(address(p))
+            .checked_write(fractionalTokenReserves);
+
+        // act
+        uint256 price = p.price();
+
+        // assert
+        assertEq(price, expectedPrice, "Price does not match");
+    }
+
+    function testPriceHas18DecimalsOfPrecision() public {
+        // arrange
+        uint256 baseTokenReserves = 0.12345e6; // 6 decimal token (e.g. USDC)
+        uint256 fractionalTokenReserves = 1e18; // 18 decimal fractional token
+        uint256 expectedPrice = 0.12345e18; // 0.12345 to 18 decimal places of accuracy
 
         // forgefmt: disable-next-item
         stdstore

--- a/test/shared/Fixture.t.sol
+++ b/test/shared/Fixture.t.sol
@@ -29,7 +29,7 @@ contract Fixture is Test, ERC721TokenReceiver {
         c = new Caviar();
 
         bayc = new MockERC721("yeet", "YEET");
-        usd = new MockERC20("us dollar", "USD");
+        usd = new MockERC20("us dollar", "USD", 6);
 
         p = c.create(address(bayc), address(usd), bytes32(0));
         lpToken = LpToken(p.lpToken());

--- a/test/shared/mocks/MockERC20.sol
+++ b/test/shared/mocks/MockERC20.sol
@@ -4,5 +4,5 @@ pragma solidity ^0.8.17;
 import "solmate/tokens/ERC20.sol";
 
 contract MockERC20 is ERC20 {
-    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_, 18) {}
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_, decimals_) {}
 }


### PR DESCRIPTION
Fixes: https://github.com/code-423n4/2022-12-caviar-findings/issues/141

Ensures that the exponent is always 18 decimals greater than the denominator (18 decimals too).