### PR TITLE
audit: add deadline parameter to trade functions

### DIFF
--- a/test/Pair/integration/AddBuySellRemove.t.sol
+++ b/test/Pair/integration/AddBuySellRemove.t.sol
@@ -22,19 +22,19 @@ contract AddBuySellRemoveTest is Fixture {
         deal(address(p), address(this), addFractionalTokenAmount, true);
         uint256 lpTokenAmount = Math.sqrt(addBaseTokenAmount * addFractionalTokenAmount) - 1000;
         usd.approve(address(p), type(uint256).max);
-        p.add(addBaseTokenAmount, addFractionalTokenAmount, lpTokenAmount, 0, type(uint256).max);
+        p.add(addBaseTokenAmount, addFractionalTokenAmount, lpTokenAmount, 0, type(uint256).max, 0);
 
         // buy some amount
         uint256 baseTokenBuyAmount = p.buyQuote(buyTokenAmount);
         deal(address(usd), address(this), baseTokenBuyAmount, true);
-        p.buy(buyTokenAmount, baseTokenBuyAmount);
+        p.buy(buyTokenAmount, baseTokenBuyAmount, 0);
 
         // remove some fraction of liquidity
         uint256 removeLpTokenAmount = lpTokenAmount / 10;
         uint256 expectedBaseTokenAmount = p.baseTokenReserves() * removeLpTokenAmount / lpToken.totalSupply();
         uint256 expectedFractionalTokenAmount =
             p.fractionalTokenReserves() * removeLpTokenAmount / lpToken.totalSupply();
-        (uint256 baseTokenOutputAmount, uint256 fractionalTokenOutputAmount) = p.remove(removeLpTokenAmount, 0, 0);
+        (uint256 baseTokenOutputAmount, uint256 fractionalTokenOutputAmount) = p.remove(removeLpTokenAmount, 0, 0, 0);
 
         assertEq(baseTokenOutputAmount, expectedBaseTokenAmount, "Should have removed correct base token amount");
         assertEq(

--- a/test/Pair/integration/BuySell.t.sol
+++ b/test/Pair/integration/BuySell.t.sol
@@ -18,11 +18,11 @@ contract BuySellTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
 
         deal(address(ethPair), address(this), fractionalTokenAmount, true);
         ethPair.add{value: baseTokenAmount}(
-            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0
         );
     }
 
@@ -33,8 +33,8 @@ contract BuySellTest is Fixture {
         deal(address(usd), address(this), maxInputAmount, true);
 
         // act
-        p.buy(outputAmount, maxInputAmount);
-        p.sell(outputAmount, 0);
+        p.buy(outputAmount, maxInputAmount, 0);
+        p.sell(outputAmount, 0, 0);
 
         // assert
         assertApproxEqAbs(

--- a/test/Pair/unit/Add.t.sol
+++ b/test/Pair/unit/Add.t.sol
@@ -33,7 +33,7 @@ contract AddTest is Fixture {
         uint256 balanceBefore = usd.balanceOf(address(this));
 
         // act
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
 
         // assert
         uint256 balanceAfter = usd.balanceOf(address(this));
@@ -47,7 +47,7 @@ contract AddTest is Fixture {
         uint256 balanceBefore = p.balanceOf(address(this));
 
         // act
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
 
         // assert
         assertEq(p.balanceOf(address(p)), fractionalTokenAmount, "Should have transferred fractional tokens to pair");
@@ -64,13 +64,13 @@ contract AddTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: lp token amount out");
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
     }
 
     function testItMintsLpTokensAfterInit() public {
         // arrange
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0); // initial add
         uint256 lpTokenSupplyBefore = lpToken.totalSupply();
 
         uint256 expectedLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) * 17;
@@ -83,7 +83,7 @@ contract AddTest is Fixture {
         // act
         vm.startPrank(babe);
         usd.approve(address(p), type(uint256).max);
-        uint256 lpTokenAmount = p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        uint256 lpTokenAmount = p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
         vm.stopPrank();
 
         // assert
@@ -95,7 +95,7 @@ contract AddTest is Fixture {
     function testItRevertsIfPriceIsGreaterThanMax() public {
         // arrange
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0); // initial add
 
         uint256 expectedLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) * 17;
         minLpTokenAmount = expectedLpTokenAmount;
@@ -106,13 +106,13 @@ contract AddTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: price out of bounds");
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, 0);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, 0, 0);
     }
 
     function testItRevertsIfPriceIsLessThanMin() public {
         // arrange
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0); // initial add
 
         uint256 expectedLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) * 17;
         minLpTokenAmount = expectedLpTokenAmount;
@@ -123,13 +123,13 @@ contract AddTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: price out of bounds");
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, type(uint256).max, type(uint256).max);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, type(uint256).max, type(uint256).max, 0);
     }
 
     function testItRevertsSlippageAfterInitMint() public {
         // arrange
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max); // initial add
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0); // initial add
 
         minLpTokenAmount = (baseTokenAmount * fractionalTokenAmount * 17) + 1; // add 1 to cause a revert
         baseTokenAmount = baseTokenAmount * 17;
@@ -137,7 +137,7 @@ contract AddTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: lp token amount out");
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
     }
 
     function testItRevertsIfValueIsNot0AndBaseTokenIsNot0() public {
@@ -148,7 +148,7 @@ contract AddTest is Fixture {
 
         // act
         vm.expectRevert("Invalid ether input");
-        p.add{value: 0.1 ether}(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        p.add{value: 0.1 ether}(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
     }
 
     function testItRevertsIfValueDoesNotMatchBaseTokenAmount() public {
@@ -160,7 +160,7 @@ contract AddTest is Fixture {
         // act
         vm.expectRevert("Invalid ether input");
         ethPair.add{value: baseTokenAmount - 1}(
-            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0
         );
     }
 
@@ -171,7 +171,7 @@ contract AddTest is Fixture {
 
         // act
         ethPair.add{value: baseTokenAmount}(
-            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0
         );
 
         // assert
@@ -184,7 +184,7 @@ contract AddTest is Fixture {
         // arrange
         uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
         ethPair.add{value: baseTokenAmount}(
-            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0
         ); // initial add
         uint256 lpTokenSupplyBefore = ethPairLpToken.totalSupply();
 
@@ -198,7 +198,7 @@ contract AddTest is Fixture {
         vm.startPrank(babe);
         deal(babe, baseTokenAmount);
         uint256 lpTokenAmount = ethPair.add{value: baseTokenAmount}(
-            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max
+            baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0
         );
         vm.stopPrank();
 
@@ -217,16 +217,27 @@ contract AddTest is Fixture {
         // act
         vm.expectEmit(true, true, true, true);
         emit Add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount);
-        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
     }
 
     function testItRevertsIfAmountIsZero() public {
         // act
         vm.expectRevert("Input token amount is zero");
-        p.add(0, fractionalTokenAmount, 0, 0, type(uint256).max);
+        p.add(0, fractionalTokenAmount, 0, 0, type(uint256).max, 0);
 
         vm.expectRevert("Input token amount is zero");
-        p.add(baseTokenAmount, 0, 0, 0, type(uint256).max);
+        p.add(baseTokenAmount, 0, 0, 0, type(uint256).max, 0);
+    }
+
+    function testItRevertsIfDeadlinePassed() public {
+        // arrange
+        uint256 minLpTokenAmount = Math.sqrt(baseTokenAmount * fractionalTokenAmount) - 1000;
+        skip(100);
+        uint256 deadline = block.timestamp - 1;
+
+        // act
+        vm.expectRevert("Expired");
+        p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, 0, deadline);
     }
 
     function testItInitMintsLpTokensToSender(uint256 _baseTokenAmount, uint256 _fractionalTokenAmount) public {
@@ -241,7 +252,8 @@ contract AddTest is Fixture {
         c.transferOwnership(owner);
 
         // act
-        uint256 lpTokenAmount = p.add(_baseTokenAmount, _fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        uint256 lpTokenAmount =
+            p.add(_baseTokenAmount, _fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
 
         // assert
         assertEq(lpTokenAmount, expectedLpTokenAmount, "Should have returned correct lp token amount");
@@ -257,7 +269,7 @@ contract AddTest is Fixture {
         deal(address(usd), address(this), _initBaseTokenAmount, true);
         deal(address(p), address(this), _initFractionalTokenAmount, true);
         uint256 initMinLpTokenAmount = Math.sqrt(_initBaseTokenAmount * _initFractionalTokenAmount) - 1000;
-        p.add(_initBaseTokenAmount, _initFractionalTokenAmount, initMinLpTokenAmount, 0, type(uint256).max); // initial add
+        p.add(_initBaseTokenAmount, _initFractionalTokenAmount, initMinLpTokenAmount, 0, type(uint256).max, 0); // initial add
         uint256 lpTokenSupplyBefore = lpToken.totalSupply();
 
         uint256 expectedLpTokenAmount = Math.sqrt(_initBaseTokenAmount * _initFractionalTokenAmount) * 17;
@@ -270,7 +282,7 @@ contract AddTest is Fixture {
         // act
         vm.startPrank(babe);
         usd.approve(address(p), type(uint256).max);
-        uint256 lpTokenAmount = p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max);
+        uint256 lpTokenAmount = p.add(baseTokenAmount, fractionalTokenAmount, minLpTokenAmount, 0, type(uint256).max, 0);
         vm.stopPrank();
 
         // assert

--- a/test/Pair/unit/NftRemove.t.sol
+++ b/test/Pair/unit/NftRemove.t.sol
@@ -24,7 +24,7 @@ contract NftRemoveTest is Fixture {
         usd.approve(address(p), type(uint256).max);
 
         uint256 minLpTokenAmount = Math.sqrt(totalBaseTokenAmount * tokenIds.length * 1e18) - 1000;
-        totalLpTokenAmount = p.nftAdd(totalBaseTokenAmount, tokenIds, minLpTokenAmount, 0, type(uint256).max, proofs);
+        totalLpTokenAmount = p.nftAdd(totalBaseTokenAmount, tokenIds, minLpTokenAmount, 0, 0, type(uint256).max, proofs);
 
         tokenIds.pop();
         tokenIds.pop();
@@ -39,7 +39,7 @@ contract NftRemoveTest is Fixture {
 
         // act
         (uint256 baseTokenAmount, uint256 fractionalTokenAmount) =
-            p.nftRemove(lpTokenAmount, expectedBaseTokenAmount, tokenIds, false);
+            p.nftRemove(lpTokenAmount, expectedBaseTokenAmount, 0, tokenIds, false);
 
         // assert
         assertEq(baseTokenAmount, expectedBaseTokenAmount, "Should have returned correct base token amount");
@@ -57,7 +57,7 @@ contract NftRemoveTest is Fixture {
         uint256 totalSupplyBefore = lpToken.totalSupply();
 
         // act
-        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, tokenIds, false);
+        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, 0, tokenIds, false);
 
         // assert
         assertEq(
@@ -75,7 +75,7 @@ contract NftRemoveTest is Fixture {
         uint256 balanceBefore = usd.balanceOf(address(p));
 
         // act
-        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, tokenIds, false);
+        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, 0, tokenIds, false);
 
         // assert
         assertEq(
@@ -91,6 +91,16 @@ contract NftRemoveTest is Fixture {
         );
     }
 
+    function testItRevertsIfDeadlinePassed() public {
+        // arrange
+        skip(100);
+        uint256 deadline = block.timestamp - 1;
+
+        // act
+        vm.expectRevert("Expired");
+        p.nftRemove(0, 0, deadline, tokenIds, false);
+    }
+
     function testItTransfersNfts() public {
         // arrange
         uint256 lpTokenAmount = (lpToken.totalSupply() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
@@ -98,7 +108,7 @@ contract NftRemoveTest is Fixture {
             (p.baseTokenReserves() * tokenIds.length * 1e18) / p.fractionalTokenReserves();
 
         // act
-        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, tokenIds, false);
+        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, 0, tokenIds, false);
 
         // assert
         for (uint256 i = 0; i < tokenIds.length; i++) {
@@ -115,7 +125,7 @@ contract NftRemoveTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: fractional token out");
-        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, tokenIds, false);
+        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, 0, tokenIds, false);
     }
 
     function testItRevertsBaseTokenSlippage() public {
@@ -126,6 +136,6 @@ contract NftRemoveTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: base token amount out");
-        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, tokenIds, false);
+        p.nftRemove(lpTokenAmount, minBaseTokenOutputAmount, 0, tokenIds, false);
     }
 }

--- a/test/Pair/unit/Remove.t.sol
+++ b/test/Pair/unit/Remove.t.sol
@@ -20,16 +20,16 @@ contract RemoveTest is Fixture {
 
         usd.approve(address(p), type(uint256).max);
 
-        p.add(totalBaseTokenAmount, totalFractionalTokenAmount, 0, 0, type(uint256).max);
-        totalLpTokenAmount = p.add(totalBaseTokenAmount, totalFractionalTokenAmount, 0, 0, type(uint256).max);
+        p.add(totalBaseTokenAmount, totalFractionalTokenAmount, 0, 0, type(uint256).max, 0);
+        totalLpTokenAmount = p.add(totalBaseTokenAmount, totalFractionalTokenAmount, 0, 0, type(uint256).max, 0);
 
         deal(address(ethPair), address(this), totalFractionalTokenAmount * 2, true);
         ethPair.add{value: totalBaseTokenAmount}(
-            totalBaseTokenAmount, totalFractionalTokenAmount, 0, 0, type(uint256).max
+            totalBaseTokenAmount, totalFractionalTokenAmount, 0, 0, type(uint256).max, 0
         );
 
         ethPair.add{value: totalBaseTokenAmount}(
-            totalBaseTokenAmount, totalFractionalTokenAmount, 0, 0, type(uint256).max
+            totalBaseTokenAmount, totalFractionalTokenAmount, 0, 0, type(uint256).max, 0
         );
     }
 
@@ -41,7 +41,7 @@ contract RemoveTest is Fixture {
 
         // act
         (uint256 baseTokenAmount, uint256 fractionalTokenAmount) =
-            p.remove(lpTokenAmount, expectedBaseTokenAmount, expectedFractionalTokenAmount);
+            p.remove(lpTokenAmount, expectedBaseTokenAmount, expectedFractionalTokenAmount, 0);
 
         // assert
         assertEq(baseTokenAmount, expectedBaseTokenAmount, "Should have returned correct base token amount");
@@ -59,7 +59,7 @@ contract RemoveTest is Fixture {
         uint256 totalSupplyBefore = lpToken.totalSupply();
 
         // act
-        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount);
+        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount, 0);
 
         // assert
         assertEq(
@@ -77,7 +77,7 @@ contract RemoveTest is Fixture {
         uint256 balanceBefore = usd.balanceOf(address(p));
 
         // act
-        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount);
+        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount, 0);
 
         // assert
         assertEq(
@@ -102,7 +102,7 @@ contract RemoveTest is Fixture {
         uint256 balanceBefore = p.balanceOf(address(p));
 
         // act
-        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount);
+        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount, 0);
 
         // assert
         assertEq(
@@ -126,7 +126,7 @@ contract RemoveTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: fractional token out");
-        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount);
+        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount, 0);
     }
 
     function testItRevertsBaseTokenSlippage() public {
@@ -137,7 +137,7 @@ contract RemoveTest is Fixture {
 
         // act
         vm.expectRevert("Slippage: base token amount out");
-        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount);
+        p.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount, 0);
     }
 
     function testItTransfersEther() public {
@@ -149,7 +149,7 @@ contract RemoveTest is Fixture {
         uint256 balanceBefore = address(ethPair).balance;
 
         // act
-        ethPair.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount);
+        ethPair.remove(lpTokenAmount, minBaseTokenOutputAmount, minFractionalTokenOutputAmount, 0);
 
         // assert
         assertEq(
@@ -174,7 +174,17 @@ contract RemoveTest is Fixture {
         // act
         vm.expectEmit(true, true, true, true);
         emit Remove(expectedBaseTokenAmount, expectedFractionalTokenAmount, lpTokenAmount);
-        p.remove(lpTokenAmount, expectedBaseTokenAmount, expectedFractionalTokenAmount);
+        p.remove(lpTokenAmount, expectedBaseTokenAmount, expectedFractionalTokenAmount, 0);
+    }
+
+    function testItRevertsIfDeadlinePassed() public {
+        // arrange
+        skip(100);
+        uint256 deadline = block.timestamp - 1;
+
+        // act
+        vm.expectRevert("Expired");
+        p.remove(0, 0, 0, deadline);
     }
 
     function testItReturnsBaseTokenAmountAndFractionalTokenAmount(uint256 fractionToRemove) public {
@@ -186,7 +196,7 @@ contract RemoveTest is Fixture {
 
         // act
         (uint256 baseTokenAmount, uint256 fractionalTokenAmount) =
-            p.remove(lpTokenAmount, expectedBaseTokenAmount, expectedFractionalTokenAmount);
+            p.remove(lpTokenAmount, expectedBaseTokenAmount, expectedFractionalTokenAmount, 0);
 
         // assert
         assertEq(baseTokenAmount, expectedBaseTokenAmount, "Should have returned correct base token amount");


### PR DESCRIPTION
Fixes: https://github.com/code-423n4/2022-12-caviar-findings/issues/116

Adds a parameter that allows traders to specify when their transactions should expire by.